### PR TITLE
check token before fetch

### DIFF
--- a/server/db/index.js
+++ b/server/db/index.js
@@ -54,79 +54,79 @@ const fetchMovieDetails = async (movieId) => {
 const syncAndSeed = async () => {
   await conn.sync({ force: false }); // Change to False when on localhost
 
-  const totalPages = 100;
+  // const totalPages = 100;
 
-  try {
-    for (let page = 1; page < totalPages; page++) {
-      const popularCastMembers = await fetchPopularCastMembers(page);
+  // try {
+  //   for (let page = 1; page < totalPages; page++) {
+  //     const popularCastMembers = await fetchPopularCastMembers(page);
 
-      for (const castMember of popularCastMembers) {
-        if (castMember.known_for_department === "Acting") {
-          let existingCastMember = await Casts.findOne({
-            where: { id: castMember.id },
-          });
+  //     for (const castMember of popularCastMembers) {
+  //       if (castMember.known_for_department === "Acting") {
+  //         let existingCastMember = await Casts.findOne({
+  //           where: { id: castMember.id },
+  //         });
 
-          if (!existingCastMember) {
-            const newCastMember = await Casts.create({
-              id: castMember.id,
-              known_for_department: castMember.known_for_department,
-              name: castMember.name,
-              known_for: castMember.known_for,
-              profile_path: castMember.profile_path,
-            });
+  //         if (!existingCastMember) {
+  //           const newCastMember = await Casts.create({
+  //             id: castMember.id,
+  //             known_for_department: castMember.known_for_department,
+  //             name: castMember.name,
+  //             known_for: castMember.known_for,
+  //             profile_path: castMember.profile_path,
+  //           });
 
-            for (const knownMovie of castMember.known_for) {
-              let movie = await Movie.findOne({ where: { id: knownMovie.id } });
+  //           for (const knownMovie of castMember.known_for) {
+  //             let movie = await Movie.findOne({ where: { id: knownMovie.id } });
 
-              if (!movie) {
-                const movieDetails = await fetchMovieDetails(knownMovie.id);
+  //             if (!movie) {
+  //               const movieDetails = await fetchMovieDetails(knownMovie.id);
 
-                if (movieDetails) {
-                  movie = await Movie.create({
-                    id: movieDetails.id,
-                    title: movieDetails.title,
-                    backdrop_path: movieDetails.backdrop_path,
-                    overview: movieDetails.overview,
-                    popularity: movieDetails.popularity,
-                    poster_path: movieDetails.poster_path,
-                    runtime: movieDetails.runtime,
-                    release_date: movieDetails.release_date,
-                    vote_average: movieDetails.vote_average,
-                    vote_count: movieDetails.vote_count,
-                  });
+  //               if (movieDetails) {
+  //                 movie = await Movie.create({
+  //                   id: movieDetails.id,
+  //                   title: movieDetails.title,
+  //                   backdrop_path: movieDetails.backdrop_path,
+  //                   overview: movieDetails.overview,
+  //                   popularity: movieDetails.popularity,
+  //                   poster_path: movieDetails.poster_path,
+  //                   runtime: movieDetails.runtime,
+  //                   release_date: movieDetails.release_date,
+  //                   vote_average: movieDetails.vote_average,
+  //                   vote_count: movieDetails.vote_count,
+  //                 });
 
-                  for (const credit of movieDetails.credits.cast) {
-                    if (credit.known_for_department === "Acting") {
-                      const castMember = await Casts.findOne({
-                        where: { id: credit.id },
-                      });
+  //                 for (const credit of movieDetails.credits.cast) {
+  //                   if (credit.known_for_department === "Acting") {
+  //                     const castMember = await Casts.findOne({
+  //                       where: { id: credit.id },
+  //                     });
 
-                      if (castMember) {
-                        await movie.addCast(castMember);
-                      } else {
-                        const newCreditCastMember = await Casts.create({
-                          id: credit.id,
-                          known_for_department: credit.known_for_department,
-                          name: credit.name,
-                          profile_path: credit.profile_path,
-                        });
-                        await movie.addCast(newCreditCastMember);
-                      }
-                    }
-                  }
-                }
-                if (movie) {
-                  await newCastMember.addMovie(movie);
-                }
-              }
-            }
-          }
-        }
-      }
-    }
-  } catch (error) {
-    console.error("Error during seeding:", error);
-  }
+  //                     if (castMember) {
+  //                       await movie.addCast(castMember);
+  //                     } else {
+  //                       const newCreditCastMember = await Casts.create({
+  //                         id: credit.id,
+  //                         known_for_department: credit.known_for_department,
+  //                         name: credit.name,
+  //                         profile_path: credit.profile_path,
+  //                       });
+  //                       await movie.addCast(newCreditCastMember);
+  //                     }
+  //                   }
+  //                 }
+  //               }
+  //               if (movie) {
+  //                 await newCastMember.addMovie(movie);
+  //               }
+  //             }
+  //           }
+  //         }
+  //       }
+  //       }
+  //     }
+  //   } catch (error) {
+  //     console.error("Error during seeding:", error);
+  //   }
 };
 
 module.exports = {

--- a/src/store/favoriteCastsSlice.js
+++ b/src/store/favoriteCastsSlice.js
@@ -1,66 +1,73 @@
 const { createAsyncThunk, createSlice } = require("@reduxjs/toolkit");
 const axios = require("axios");
 
-
-const fetchFavoriteCasts = createAsyncThunk('getFavoriteCasts', async () => {
-    try {
-        const token = window.localStorage.getItem("token");
-        const response = await axios.get("/api/favorites/casts", {
-            headers: {
-                authorization: token
-            }
-        });
-        return response.data
-    } catch (e) {
-        console.log(e);
-    }
+const fetchFavoriteCasts = createAsyncThunk("getFavoriteCasts", async () => {
+  const token = window.localStorage.getItem("token");
+  // Don't make the request if the token doesn't exist
+  if (!token) return [];
+  try {
+    const response = await axios.get("/api/favorites/casts", {
+      headers: {
+        authorization: token,
+      },
+    });
+    return response.data;
+  } catch (e) {
+    console.log(e);
+  }
 });
 
-const addFavoriteCast = createAsyncThunk('addFavoriteCast', async (castId) => {
-    try {
-        const token = window.localStorage.getItem("token");
-        const response = await axios.post("/api/favorites/cast",{castId}, {
-            headers: {
-                authorization: token
-            }
-        });
-        return response.data
-    } catch (e) {
-        console.log(e);
-    }
+const addFavoriteCast = createAsyncThunk("addFavoriteCast", async (castId) => {
+  try {
+    const token = window.localStorage.getItem("token");
+    const response = await axios.post(
+      "/api/favorites/cast",
+      { castId },
+      {
+        headers: {
+          authorization: token,
+        },
+      }
+    );
+    return response.data;
+  } catch (e) {
+    console.log(e);
+  }
 });
 
-const deleteFavoriteCast = createAsyncThunk('deleteFavoriteCast', async (id) => {
+const deleteFavoriteCast = createAsyncThunk(
+  "deleteFavoriteCast",
+  async (id) => {
     try {
-        const token = window.localStorage.getItem("token");
-        const response = await axios.delete(`/api/favorites/cast/${id}`, {
-            headers: {
-                authorization: token
-            }
-        });
-        return response.data
+      const token = window.localStorage.getItem("token");
+      const response = await axios.delete(`/api/favorites/cast/${id}`, {
+        headers: {
+          authorization: token,
+        },
+      });
+      return response.data;
     } catch (e) {
-        console.log(e);
+      console.log(e);
     }
-})
+  }
+);
 
 const favoriteCastsSlice = createSlice({
-    name: "favoriteCasts",
-    initialState: [],
-    reducers:{},
-    extraReducers: (builder) => {
-        builder.addCase(fetchFavoriteCasts.fulfilled, (state, action) => {
-            return action.payload;
-        });
-        builder.addCase(addFavoriteCast.fulfilled, (state, action) => {
-            return [...state, action.payload]
-        });
-        builder.addCase(deleteFavoriteCast.fulfilled, (state, action) => {
-            return state.filter((cast) => cast.id !== action.payload.id)
-        });
-    }
-})
-
+  name: "favoriteCasts",
+  initialState: [],
+  reducers: {},
+  extraReducers: (builder) => {
+    builder.addCase(fetchFavoriteCasts.fulfilled, (state, action) => {
+      return action.payload;
+    });
+    builder.addCase(addFavoriteCast.fulfilled, (state, action) => {
+      return [...state, action.payload];
+    });
+    builder.addCase(deleteFavoriteCast.fulfilled, (state, action) => {
+      return state.filter((cast) => cast.id !== action.payload.id);
+    });
+  },
+});
 
 export default favoriteCastsSlice.reducer;
-export {fetchFavoriteCasts, addFavoriteCast, deleteFavoriteCast};
+export { fetchFavoriteCasts, addFavoriteCast, deleteFavoriteCast };

--- a/src/store/favoriteMoviesSlice.js
+++ b/src/store/favoriteMoviesSlice.js
@@ -1,66 +1,76 @@
-const { createAsyncThunk, createSlice} = require("@reduxjs/toolkit");
-const  axios  = require("axios");
+const { createAsyncThunk, createSlice } = require("@reduxjs/toolkit");
+const axios = require("axios");
 
-
-const fetchFavoriteMovies = createAsyncThunk('getFavoriteMovies', async () => {
-    try {
-        const token = window.localStorage.getItem("token");
-        const response = await axios.get("/api/favorites/movies", {
-            headers: {
-                authorization: token
-            }
-        });
-        return response.data
-    } catch (e) {
-        console.log(e);
-    }
+const fetchFavoriteMovies = createAsyncThunk("getFavoriteMovies", async () => {
+  const token = window.localStorage.getItem("token");
+  // Don't make the request if the token doesn't exist
+  if (!token) return [];
+  try {
+    const response = await axios.get("/api/favorites/movies", {
+      headers: {
+        authorization: token,
+      },
+    });
+    return response.data;
+  } catch (e) {
+    console.log(e);
+  }
 });
 
-const addFavoriteMovie = createAsyncThunk('addFavoriteMovie', async (movieId) => {
+const addFavoriteMovie = createAsyncThunk(
+  "addFavoriteMovie",
+  async (movieId) => {
     try {
-        const token = window.localStorage.getItem("token");
-        const response = await axios.post("/api/favorites/movie", {movieId}, {
-            headers: {
-                authorization: token
-            }
-        });
-        return response.data
+      const token = window.localStorage.getItem("token");
+      const response = await axios.post(
+        "/api/favorites/movie",
+        { movieId },
+        {
+          headers: {
+            authorization: token,
+          },
+        }
+      );
+      return response.data;
     } catch (e) {
-        console.log(e);
+      console.log(e);
     }
-});
+  }
+);
 
-const deleteFavoriteMovie = createAsyncThunk('deleteFavoriteMovie', async (id) => {
+const deleteFavoriteMovie = createAsyncThunk(
+  "deleteFavoriteMovie",
+  async (id) => {
     try {
-        const token = window.localStorage.getItem("token");
-        const response = await axios.delete(`/api/favorites/movie/${id}`, {
-            headers: {
-                authorization: token
-            }
-        });
-        return response.data
+      const token = window.localStorage.getItem("token");
+      const response = await axios.delete(`/api/favorites/movie/${id}`, {
+        headers: {
+          authorization: token,
+        },
+      });
+      return response.data;
     } catch (e) {
-        console.log(e);
+      console.log(e);
     }
-})
+  }
+);
 
 const favoriteMovieSlice = createSlice({
-    name: "favoriteMovies",
-    initialState: [],
-    reducers:{},
-    extraReducers: (builder) => {
-        builder.addCase(fetchFavoriteMovies.fulfilled, (state, action) => {
-            return action.payload;
-        });
-        builder.addCase(addFavoriteMovie.fulfilled, (state, action) => {
-            return [...state, action.payload]
-        });
-        builder.addCase(deleteFavoriteMovie.fulfilled, (state, action) => {
-            return state.filter((movie) => movie.id !== action.payload.id)
-        });
-    }
-})
-
+  name: "favoriteMovies",
+  initialState: [],
+  reducers: {},
+  extraReducers: (builder) => {
+    builder.addCase(fetchFavoriteMovies.fulfilled, (state, action) => {
+      return action.payload;
+    });
+    builder.addCase(addFavoriteMovie.fulfilled, (state, action) => {
+      return [...state, action.payload];
+    });
+    builder.addCase(deleteFavoriteMovie.fulfilled, (state, action) => {
+      return state.filter((movie) => movie.id !== action.payload.id);
+    });
+  },
+});
 
 export default favoriteMovieSlice.reducer;
-export {fetchFavoriteMovies, addFavoriteMovie, deleteFavoriteMovie};
+export { fetchFavoriteMovies, addFavoriteMovie, deleteFavoriteMovie };


### PR DESCRIPTION
check in fetches added to check for token from localStorage and if the token is null or undefined (meaning the user is not authenticated), we return an empty array and skip the API request altogether to avoid 401 error for unauthenticated users when initially going to Single Actor or Single Movie page.